### PR TITLE
codespell: config, action  + typos fixed

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+skip = .git,*.pdf,*.svg,package-lock.json
+#
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,3 @@
 [codespell]
-skip = .git,*.pdf,*.svg,package-lock.json
-#
-# ignore-words-list =
+skip = .git,*.pdf,*.svg,package-lock.json,*.json,yarn.lock
+ignore-words-list = inflight

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,19 @@
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v1

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Out of the box, Metabob uses a tuned version of Meta AI's OPT model to generate 
 5. On the pop-up box, click **_"Fix"_** to open Metabob's extension panel to view more details about the problem and automatically generate a code recommendation for a fix **OR** click **_"More Details"_** to open the extension panel to just view more details about the problem  
 ![problem-pop-up-commands](docs/img/docs-popup-commands.png)
 ​
-6. You can **_"discard"_** the problem if you think it is invalid or unuseful. You can **_"endorse"_** the problem if you think it is valid or useful  
+6. You can **_"discard"_** the problem if you think it is invalid or useless. You can **_"endorse"_** the problem if you think it is valid or useful  
 ![discard-or-endorse](docs/img/docs-discard-endorse.png)
 ​
 7. Ask questions about the problem description or pass in more context by using the text field below the problem description and clicking **_"ask"_** after  

--- a/ext-src/constants.ts
+++ b/ext-src/constants.ts
@@ -3,10 +3,10 @@ export const CONSTANTS = {
   sessionKey: '@metabob/sessionToken',
   apiKey: '@metabob/apiKey',
   analyze: '@metabob/analyze',
-  recomendations: '@metabob/recomendations',
+  recommendations: '@metabob/recommendations',
   currentQuestion: '@metabob/currentquestion',
 
-  // Command Registeration String
+  // Command Registration String
   analyzeDocumentCommand: 'metabob.analyzeDocument',
   discardSuggestionCommand: 'metabob.discardSuggestion',
   endorseSuggestionCommand: 'metabob.endorseSuggestion',

--- a/ext-src/extension.ts
+++ b/ext-src/extension.ts
@@ -17,7 +17,7 @@ export function activate(context: vscode.ExtensionContext) {
   const analyzeDocumentOnSave = analyzeDocumentOnSaveConfig()
 
   // Create User Session, If already created get the refresh token
-  // otherwise, ping server every 60 second to not destory the token
+  // otherwise, ping server every 60 second to not destroy the token
   // if the user has not done any activity
   createOrUpdateUserSession(context)
 
@@ -118,7 +118,7 @@ export function activate(context: vscode.ExtensionContext) {
     })
   )
 
-  // Recomendation Panel Webview Provider that is the normal Metabob workflow
+  // Recommendation Panel Webview Provider that is the normal Metabob workflow
   context.subscriptions.push(
     vscode.window.registerWebviewViewProvider(
       'recommendation-panel-webview',

--- a/ext-src/extension.ts
+++ b/ext-src/extension.ts
@@ -42,7 +42,7 @@ export function activate(context: vscode.ExtensionContext) {
   // Used to notify the model about positive feedback
   activateEndorseCommand(context, debug)
 
-  // Depreceated
+  // Deprecated
   activateFocusRecomendCommand(context, debug)
 
   // When the user click the detail button on the problem

--- a/ext-src/store/analyze.state.ts
+++ b/ext-src/store/analyze.state.ts
@@ -15,7 +15,7 @@ export type IAnalyzeState = {
   }
 }
 
-// Whenver the user Analyze the file, we will store the response of the request in
+// Whenever the user Analyze the file, we will store the response of the request in
 // a store, so user will be able to see decorations upon changing files.
 export class AnalyzeState extends ExtensionState<IAnalyzeState> {
   constructor(context: vscode.ExtensionContext) {

--- a/ext-src/store/apiKey.state.ts
+++ b/ext-src/store/apiKey.state.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 import { CONSTANTS } from '../constants'
 import { ExtensionState, ExtensionStateValue } from './base.state'
 
-// API Keys Global state, that is updated whenever the user changes config of the Extesnion.
+// API Keys Global state, that is updated whenever the user changes config of the Extension.
 export class ApiKeyState extends ExtensionState<string> {
   constructor(context: vscode.ExtensionContext) {
     super(context, CONSTANTS.apiKey)

--- a/ext-src/store/currentQuestion.state.ts
+++ b/ext-src/store/currentQuestion.state.ts
@@ -3,7 +3,7 @@ import { CONSTANTS } from '../constants'
 import { Problem } from '../types'
 import { ExtensionState, ExtensionStateValue } from './base.state'
 
-// Whenver the Metabob extension is opened by the user, we want to
+// Whenever the Metabob extension is opened by the user, we want to
 // add previous question performed by the user, so upon asking question,
 // we update this state and upon activate we perform get from this state
 export type ICurrentQuestionState = {

--- a/ext-src/store/recomendations.state.ts
+++ b/ext-src/store/recomendations.state.ts
@@ -11,14 +11,14 @@ export type IRecomendationState = [
     endLine?: number
     category?: string
     summary?: string
-    recomendations?: string
+    recommendations?: string
   }
 ]
 
-// This is used when user performs recomendation from the Metabob, this state store the current value.
+// This is used when user performs recommendation from the Metabob, this state store the current value.
 export class RecomendationState extends ExtensionState<IRecomendationState> {
   constructor(context: vscode.ExtensionContext) {
-    super(context, CONSTANTS.recomendations)
+    super(context, CONSTANTS.recommendations)
   }
 
   get(): ExtensionStateValue<IRecomendationState> | undefined {

--- a/src/RecomendationPanel.tsx
+++ b/src/RecomendationPanel.tsx
@@ -55,7 +55,7 @@ export const RecomendationPanel = () => {
     <>
       <div className="className='w-full'">
         <div className='flex flex-wrap my-3 flex-row mx-auto justify-between'>
-          <span className='font-bold text-clifford text-1xl transition duration-300 antialiased'>Recomendation</span>
+          <span className='font-bold text-clifford text-1xl transition duration-300 antialiased'>Recommendation</span>
           {!isgenerateClicked ? (
             <>
               <span className='order-last'>
@@ -104,7 +104,7 @@ export const RecomendationPanel = () => {
                   className='appearance-none bg-transparent border-none w-full mr-3 py-1 px-2 leading-tight focus:outline-none'
                   type='text'
                   placeholder='Enter text here'
-                  aria-label='your question about recomendation?'
+                  aria-label='your question about recommendation?'
                   onChange={handleQuestionChange}
                   value={userQuestionAboutRecomendation}
                 />


### PR DESCRIPTION
one typo - missing `m` in `recommendation[s]` might be functionally affecting and needs changes elsewhere too... just was reacting to some spam email about metabob - looks inside ;)