### PR TITLE
Fix: Per Project State and UI changes

### DIFF
--- a/ext-src/commands/DetailDocument.ts
+++ b/ext-src/commands/DetailDocument.ts
@@ -16,6 +16,7 @@ export function activateDetailSuggestionCommand(context: vscode.ExtensionContext
     vuln: Problem;
     jobId: string;
   }) => {
+    const currentWorkSpaceFolder = Utils.getRootFolderName();
     const key = `${args.path}@@${args.id}`;
     const setAnalyzeState = new Analyze(context);
     const analyzeStateValue = new Analyze(context).get()?.value;
@@ -77,6 +78,13 @@ export function activateDetailSuggestionCommand(context: vscode.ExtensionContext
       extensionEventEmitter.fire({
         type: 'CURRENT_FILE',
         data: { ...documentMetaData.editor.document },
+      });
+
+      getExtensionEventEmitter().fire({
+        type: 'CURRENT_PROJECT',
+        data: {
+          name: currentWorkSpaceFolder
+        },
       });
     }, 500);
 

--- a/ext-src/commands/DiscardSuggestion.ts
+++ b/ext-src/commands/DiscardSuggestion.ts
@@ -13,7 +13,7 @@ export function activateDiscardCommand(context: vscode.ExtensionContext): void {
   const command = CONSTANTS.discardSuggestionCommand;
 
   const commandHandler = async (args: DiscardCommandHandler) => {
-    let isDecorationsApplied = false;
+    const currentWorkSpaceFolder = Utils.getRootFolderName();
     const analyzeState = new Analyze(context);
     const problems = analyzeState.get()?.value;
 
@@ -66,7 +66,7 @@ export function activateDiscardCommand(context: vscode.ExtensionContext): void {
     }
 
     if (isUserOnProblemFile) {
-      isDecorationsApplied = Utils.decorateCurrentEditorWithHighlights(
+      Utils.decorateCurrentEditorWithHighlights(
         results,
         documentMetaData.editor,
       );
@@ -85,6 +85,13 @@ export function activateDiscardCommand(context: vscode.ExtensionContext): void {
     extensionEventEmitter.fire({
       type: 'CURRENT_FILE',
       data: { ...documentMetaData.editor.document },
+    });
+
+    getExtensionEventEmitter().fire({
+      type: 'CURRENT_PROJECT',
+      data: {
+        name: currentWorkSpaceFolder
+      },
     });
 
     await Promise.allSettled([

--- a/ext-src/events.ts
+++ b/ext-src/events.ts
@@ -9,6 +9,7 @@ export interface AnalysisEvents {
   | 'No_Editor_Detected'
   | 'FIX_SUGGESTION'
   | 'CURRENT_FILE'
+  | 'CURRENT_PROJECT'
   | 'INIT_DATA_UPON_NEW_FILE_OPEN';
   data: any;
 }

--- a/ext-src/state/Analyze.ts
+++ b/ext-src/state/Analyze.ts
@@ -1,50 +1,51 @@
-import * as vscode from 'vscode'
-import CONSTANTS from '../constants'
-import { ExtensionState, ExtensionStateValue } from './Base'
+import * as vscode from 'vscode';
+import CONSTANTS from '../constants';
+import { ExtensionState, ExtensionStateValue } from './Base';
 
 export type AnalyseMetaData = {
-  id: string
-  path: string
-  startLine: number
-  endLine: number
-  category: string
-  summary: string
-  description: string
-  severity: string
-  isDiscarded?: boolean
+  id: string;
+  path: string;
+  startLine: number;
+  endLine: number;
+  category: string;
+  summary: string;
+  description: string;
+  severity: string;
+  isDiscarded?: boolean;
   isEndorsed?: boolean;
-  isViewed?: boolean
-}
+  isViewed?: boolean;
+  fullFilePath?: string;
+};
 
 export type AnalyzeState = {
-  [filepathAndProblemId: string]: AnalyseMetaData
-}
+  [filepathAndProblemId: string]: AnalyseMetaData;
+};
 
 // Whenever the user Analyze the file, we will store the response of the request in
 // a store, so user will be able to see decorations upon changing files.
 export class Analyze extends ExtensionState<AnalyzeState> {
   constructor(context: vscode.ExtensionContext) {
-    super(context, CONSTANTS.analyze)
+    super(context, CONSTANTS.analyze);
   }
 
   get(): ExtensionStateValue<AnalyzeState> | undefined {
-    return this.context.globalState.get<ExtensionStateValue<AnalyzeState>>(this.key)
+    return this.context.globalState.get<ExtensionStateValue<AnalyzeState>>(this.key);
   }
 
   set(value: AnalyzeState): Thenable<void> {
-    const stateValue = { key: this.key, value }
+    const stateValue = { key: this.key, value };
 
-    return this.context.globalState.update(this.key, stateValue)
+    return this.context.globalState.update(this.key, stateValue);
   }
 
   update(callback: (value: AnalyzeState) => AnalyzeState): Thenable<void | undefined> {
-    const currentValue = this.get()?.value ?? {}
-    const updatedValue = callback(currentValue)
+    const currentValue = this.get()?.value ?? {};
+    const updatedValue = callback(currentValue);
 
-    return this.set(updatedValue)
+    return this.set(updatedValue);
   }
 
   clear(): void {
-    this.context.globalState.update(this.key, undefined)
+    this.context.globalState.update(this.key, undefined);
   }
 }

--- a/ext-src/utils.ts
+++ b/ext-src/utils.ts
@@ -12,6 +12,7 @@ import {
 import { GenerateDecorations, decorationType } from './helpers';
 import CONSTANTS from './constants';
 import { AnalyzeState } from './state';
+import debugChannel from './debug';
 
 // Normal Utilities used shared across folders
 export default class Utils {
@@ -128,6 +129,17 @@ export default class Utils {
     return vscode.workspace.openTextDocument(uri).then(document => {
       return vscode.window.showTextDocument(document, vscode.ViewColumn.One);
     });
+  }
+
+  static getRootFolderName(): string | undefined {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+
+    if (workspaceFolders) {
+      const rootFolder = workspaceFolders[0];
+      return rootFolder.name;
+    }
+
+    return undefined; // No workspace folder
   }
 
   static getFileNameFromCurrentEditor(): {

--- a/src/components/Analyze/ProblemList/index.tsx
+++ b/src/components/Analyze/ProblemList/index.tsx
@@ -52,17 +52,17 @@ export const ProblemList = ({
                     <ListItem key={index} sx={ListItemStyles}>
                       <Grid
                         container
-                        spacing={theme.spacing(2)}
+                        spacing={theme.spacing(0.1)}
                         direction='row'
                         justifyContent='space-evenly'
                         alignItems='center'
                       >
-                        <Grid item xs={8}>
-                          <Typography variant='body1' sx={ListItemTypography} noWrap>
+                        <Grid item xs={7}>
+                          <Typography variant='body2' sx={ListItemTypography} noWrap>
                             {item.name}
                           </Typography>
                         </Grid>
-                        <Grid item xs={4} sx={ButtonGrid}>
+                        <Grid item xs={5} sx={ButtonGrid}>
                           <Button
                             sx={ListItemButton}
                             size='small'

--- a/src/components/Analyze/ProblemList/styles.ts
+++ b/src/components/Analyze/ProblemList/styles.ts
@@ -2,13 +2,14 @@ import { SxProps, Theme } from '@mui/material';
 
 export const ListHeaderTypography: SxProps = {
   fontWeight: '600',
-  textAlign: 'left',
+  textAlign: 'center',
 };
 
 export const ListContainer: SxProps = {
   marginLeft: -2,
   height: "200px",
   overflowY: "scroll",
+  width: "120%"
 };
 
 export const ListItemStyles: SxProps = {
@@ -34,7 +35,7 @@ export const ProblemListContainer: (theme: Theme) => SxProps = theme => ({
 export const ProblemListHeading: (theme: Theme) => SxProps = theme => ({
   marginBottom: theme.spacing(10),
   fontWeight: '600',
-  textAlign: 'left',
+  textAlign: 'center',
 });
 
 export const ButtonGrid: SxProps = {

--- a/src/components/Sugggestion/styles.ts
+++ b/src/components/Sugggestion/styles.ts
@@ -1,8 +1,5 @@
 import { SxProps } from '@mui/material';
 
-export const generateRecommendationButton: SxProps = {
-  color: 'whitesmoke',
-};
 
 export const feedbackContainer: SxProps = {
   marginTop: '20px',

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -27,6 +27,7 @@ const AccountSettingProvider = ({ children }: Props): JSX.Element => {
   const setIdentifiedProblems = useSetRecoilState(State.identifiedProblems);
   const setAnalysisLoading = useSetRecoilState(State.isAnalysisLoading);
   const setCurrentEditor = useSetRecoilState(State.currentEditor);
+  const setCurrentWorkSpaceProject = useSetRecoilState(State.currentWorkSpaceProject);
 
   const handleMessagesFromExtension = useCallback(
     (event: MessageEvent<MessageType>) => {
@@ -121,6 +122,12 @@ const AccountSettingProvider = ({ children }: Props): JSX.Element => {
         case EventDataType.ENDORSE_SUGGESTION_SUCCESS: {
           break;
         }
+        case EventDataType.CURRENT_PROJECT:
+          const { name } = payload;
+          if (name) {
+            setCurrentWorkSpaceProject(name);
+          }
+          break;
         case EventDataType.CURRENT_FILE:
           const filename: string | undefined = payload.fileName.split('/').pop();
           if (!filename) {
@@ -134,6 +141,7 @@ const AccountSettingProvider = ({ children }: Props): JSX.Element => {
       }
     },
     [
+      setCurrentWorkSpaceProject,
       setCurrentEditor,
       setApplicationState,
       setAnalysisLoading,

--- a/src/state/atoms/index.ts
+++ b/src/state/atoms/index.ts
@@ -58,3 +58,8 @@ export const currentEditor = atom<string | undefined>({
   default: undefined,
   key: 'Metabob:currentEditor'
 })
+
+export const currentWorkSpaceProject = atom<string | undefined>({
+  default: undefined,
+  key: 'Metabob:currentWorkSpaceProject'
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,8 @@ export enum EventDataType {
   NO_EDITOR_DETECTED = 'No_Editor_Detected',
   FIX_SUGGESTION = 'FIX_SUGGESTION',
   CURRENT_FILE = 'CURRENT_FILE',
-  INIT_DATA_UPON_NEW_FILE_OPEN = 'INIT_DATA_UPON_NEW_FILE_OPEN'
+  CURRENT_PROJECT = 'CURRENT_PROJECT',
+  INIT_DATA_UPON_NEW_FILE_OPEN = 'INIT_DATA_UPON_NEW_FILE_OPEN',
 }
 
 export enum ApplicationWebviewState {
@@ -53,18 +54,19 @@ export interface RecommendationPayload {
 }
 
 export type AnalyseMetaData = {
-  id: string
-  path: string
-  startLine: number
-  endLine: number
-  category: string
-  summary: string
-  description: string
-  severity: string
-  isDiscarded?: boolean
+  id: string;
+  path: string;
+  startLine: number;
+  endLine: number;
+  category: string;
+  summary: string;
+  description: string;
+  severity: string;
+  isDiscarded?: boolean;
   isEndorsed?: boolean;
-  isViewed?: boolean
-}
+  isViewed?: boolean;
+  fullFilePath?: string;
+};
 
 export type AnalyzeState = {
   [filepathAndProblemId: string]: AnalyseMetaData;


### PR DESCRIPTION
# Changes
1. Fix an edge where if the user performed analyses on one vscode workspace and opened a new one, the `other file with problems` would show previous workspace problems as well. Now each problem is tied to its workspace folder + file in that workspace and we show only current Workspace + current file problems
2. Minor UI improvements.