### PR TITLE
fix: edge case where no problem detected should be shown

### DIFF
--- a/ext-src/events.ts
+++ b/ext-src/events.ts
@@ -10,7 +10,8 @@ export interface AnalysisEvents {
   | 'FIX_SUGGESTION'
   | 'CURRENT_FILE'
   | 'CURRENT_PROJECT'
-  | 'INIT_DATA_UPON_NEW_FILE_OPEN';
+  | 'INIT_DATA_UPON_NEW_FILE_OPEN'
+  | 'Analysis_Completed_Empty_Problems';
   data: any;
 }
 

--- a/ext-src/helpers/HandleDocumentAnalyze.ts
+++ b/ext-src/helpers/HandleDocumentAnalyze.ts
@@ -201,6 +201,24 @@ export const handleDocumentAnalyze = async (
   }
 
   await analyzeState.set(results);
+
+  if (problems.length === 0) {
+    getExtensionEventEmitter().fire({
+      type: 'Analysis_Completed_Empty_Problems',
+      data: { shouldResetRecomendation: true, shouldMoveToAnalyzePage: true, ...results },
+    });
+
+    getExtensionEventEmitter().fire({
+      type: 'CURRENT_PROJECT',
+      data: {
+        name: currentWorkSpaceFolder
+      },
+    });
+
+    return verifiedResponse
+  }
+
+
   getExtensionEventEmitter().fire({
     type: 'Analysis_Completed',
     data: { shouldResetRecomendation: true, shouldMoveToAnalyzePage: true, ...results },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "metabob",
   "displayName": "Metabob: Debug and Refactor with AI",
   "description": "Generative AI to automate debugging and refactoring Python code",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "icon": "media/extension-icon.png",
   "repository": {
     "url": "https://github.com/MetabobProject/metabob-vscode",

--- a/src/components/Analyze/ProblemList/index.spec.tsx
+++ b/src/components/Analyze/ProblemList/index.spec.tsx
@@ -26,7 +26,11 @@ describe('ProblemList component', () => {
   test('renders correctly with detectedProblems', () => {
     const { getByText } = render(
       <RecoilRoot>
-        <ProblemList detectedProblems={3} otherFileWithProblems={[]} />
+        <ProblemList
+          detectedProblems={3}
+          otherFileWithProblems={[]}
+          isEmptyIdentifiedProblemDetected={false}
+        />
       </RecoilRoot>,
     );
     expect(getByText('3 Problems Detected')).toBeInTheDocument();
@@ -36,9 +40,14 @@ describe('ProblemList component', () => {
     const otherFileWithProblems = [{ name: 'file1.txt' }, { name: 'file2.txt' }];
     const { getByText, getAllByText } = render(
       <RecoilRoot>
-        <ProblemList detectedProblems={0} otherFileWithProblems={otherFileWithProblems} />
+        <ProblemList
+          detectedProblems={0}
+          otherFileWithProblems={otherFileWithProblems}
+          isEmptyIdentifiedProblemDetected={true}
+        />
       </RecoilRoot>,
     );
+    expect(getByText('No Problems Detected')).toBeInTheDocument();
     expect(getByText('Other files with problems')).toBeInTheDocument();
     otherFileWithProblems.forEach(({ name }) => {
       expect(getAllByText(name)).toHaveLength(1); // Ensure each file name is rendered once
@@ -49,9 +58,14 @@ describe('ProblemList component', () => {
     const otherFileWithProblems = [{ name: 'file1.txt' }];
     const { getByText } = render(
       <RecoilRoot>
-        <ProblemList detectedProblems={0} otherFileWithProblems={otherFileWithProblems} />
+        <ProblemList
+          detectedProblems={0}
+          otherFileWithProblems={otherFileWithProblems}
+          isEmptyIdentifiedProblemDetected={true}
+        />
       </RecoilRoot>,
     );
+    expect(getByText('No Problems Detected')).toBeInTheDocument();
     fireEvent.click(getByText('Open'));
     expect(vscode.postMessage).toHaveBeenCalledWith({
       type: 'OPEN_FILE_IN_NEW_TAB',

--- a/src/components/Analyze/ProblemList/index.tsx
+++ b/src/components/Analyze/ProblemList/index.tsx
@@ -14,11 +14,13 @@ import { useCallback } from 'react';
 export interface ProblemsListProps {
   detectedProblems?: number;
   otherFileWithProblems?: Array<{ name: string }>;
+  isEmptyIdentifiedProblemDetected: boolean;
 }
 
 export const ProblemList = ({
   otherFileWithProblems,
   detectedProblems,
+  isEmptyIdentifiedProblemDetected,
 }: ProblemsListProps): JSX.Element => {
   const theme = useTheme();
 
@@ -39,6 +41,12 @@ export const ProblemList = ({
         {detectedProblems !== undefined && detectedProblems !== 0 && (
           <Typography variant='h6' sx={ProblemListHeading(theme)}>
             {detectedProblems} Problems Detected
+          </Typography>
+        )}
+
+        {isEmptyIdentifiedProblemDetected === true && (
+          <Typography variant='h6' sx={ProblemListHeading(theme)}>
+            No Problems Detected
           </Typography>
         )}
 

--- a/src/components/Analyze/index.tsx
+++ b/src/components/Analyze/index.tsx
@@ -24,6 +24,7 @@ export const AnalyzePage = ({
   const identifiedProblems = useRecoilValue(State.identifiedProblems);
   const currentEditor = useRecoilValue(State.currentEditor);
   const currentWorkSpaceProject = useRecoilValue(State.currentWorkSpaceProject);
+  const isEmptyIdentifiedProblemDetected = useRecoilValue(State.isEmptyIdentifiedProblemDetected);
 
   const otherFileWithProblems: Array<{ name: string }> | undefined = useMemo(() => {
     if (!identifiedProblems) return undefined;
@@ -186,6 +187,7 @@ export const AnalyzePage = ({
         <ProblemList
           detectedProblems={detectedProblems}
           otherFileWithProblems={otherFileWithProblems}
+          isEmptyIdentifiedProblemDetected={isEmptyIdentifiedProblemDetected}
         />
       )}
     </>

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -35,7 +35,6 @@ const AccountSettingProvider = ({ children }: Props): JSX.Element => {
   const handleMessagesFromExtension = useCallback(
     (event: MessageEvent<MessageType>) => {
       const payload = event.data.data;
-      console.log(payload);
       switch (event.data.type) {
         case EventDataType.NO_EDITOR_DETECTED:
           setApplicationState(ApplicationWebviewState.ANALYZE_MODE);

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -28,10 +28,14 @@ const AccountSettingProvider = ({ children }: Props): JSX.Element => {
   const setAnalysisLoading = useSetRecoilState(State.isAnalysisLoading);
   const setCurrentEditor = useSetRecoilState(State.currentEditor);
   const setCurrentWorkSpaceProject = useSetRecoilState(State.currentWorkSpaceProject);
+  const setIsEmptyIdentifiedProblemDetected = useSetRecoilState(
+    State.isEmptyIdentifiedProblemDetected,
+  );
 
   const handleMessagesFromExtension = useCallback(
     (event: MessageEvent<MessageType>) => {
       const payload = event.data.data;
+      console.log(payload);
       switch (event.data.type) {
         case EventDataType.NO_EDITOR_DETECTED:
           setApplicationState(ApplicationWebviewState.ANALYZE_MODE);
@@ -51,8 +55,25 @@ const AccountSettingProvider = ({ children }: Props): JSX.Element => {
         case EventDataType.ANALYSIS_ERROR:
           setIsAnalysisLoading(false);
           break;
+        case EventDataType.ANALYSIS_COMPLETED_EMPTY_PROBLEMS: {
+          const { shouldResetRecomendation, shouldMoveToAnalyzePage, ...problem } = payload;
+          setIsEmptyIdentifiedProblemDetected(true);
+          if (problem) {
+            setIdentifiedProblems(problem as AnalyzeState);
+          }
+          if (shouldMoveToAnalyzePage) {
+            setIdentifiedSuggestion(undefined);
+            setApplicationState(ApplicationWebviewState.ANALYZE_MODE);
+          }
+          if (shouldResetRecomendation) {
+            setIdentifiedRecommendation(undefined);
+          }
+          setIsAnalysisLoading(false);
+          break;
+        }
         case EventDataType.ANALYSIS_COMPLETED:
           const { shouldResetRecomendation, shouldMoveToAnalyzePage, ...problem } = payload;
+          setIsEmptyIdentifiedProblemDetected(false);
           if (problem) {
             setIdentifiedProblems(problem as AnalyzeState);
           }

--- a/src/state/atoms/index.ts
+++ b/src/state/atoms/index.ts
@@ -54,6 +54,11 @@ export const identifiedProblems = atom<AnalyzeState | undefined>({
   effects_UNSTABLE: [persistAtom]
 });
 
+export const isEmptyIdentifiedProblemDetected = atom<boolean>({
+  default: false,
+  key: "Metabob:isEmptyIdentifiedProblemDetected"
+})
+
 export const currentEditor = atom<string | undefined>({
   default: undefined,
   key: 'Metabob:currentEditor',

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export enum EventDataType {
   CURRENT_FILE = 'CURRENT_FILE',
   CURRENT_PROJECT = 'CURRENT_PROJECT',
   INIT_DATA_UPON_NEW_FILE_OPEN = 'INIT_DATA_UPON_NEW_FILE_OPEN',
+  ANALYSIS_COMPLETED_EMPTY_PROBLEMS = 'Analysis_Completed_Empty_Problems'
 }
 
 export enum ApplicationWebviewState {


### PR DESCRIPTION
# Description
Fix the edge case where if the server sends no problems, so do not show "No Problems detected"

# After the fix
Whenever the server has an empty problems response, we do show "No Problem detected" in the UI

# Tests
Test cases are updated to expect "No Problem detected" text whenever the prop `isEmptyIdentifiedProblemDetected` is true.