### PR TITLE
fix file path not being sent to backend

### DIFF
--- a/ext-src/commands/DetailDocument.ts
+++ b/ext-src/commands/DetailDocument.ts
@@ -22,7 +22,7 @@ export function activateDetailSuggestionCommand(context: vscode.ExtensionContext
     const sessionToken = new Session(context).get()?.value;
     const extensionEventEmitter = getExtensionEventEmitter();
 
-    const documentMetaData = Utils.getFileNameFromCurrentEditor();
+    const documentMetaData = Utils.getCurrentFile();
 
     if (!documentMetaData) {
       vscode.window.showErrorMessage(CONSTANTS.editorNotSelectorError);

--- a/ext-src/commands/DiscardSuggestion.ts
+++ b/ext-src/commands/DiscardSuggestion.ts
@@ -33,7 +33,7 @@ export function activateDiscardCommand(context: vscode.ExtensionContext): void {
     }
 
     // verifying that in-fact user viewing problem.path file.
-    const documentMetaData = Utils.getFileNameFromCurrentEditor();
+    const documentMetaData = Utils.getCurrentFile();
     if (!documentMetaData) {
       vscode.window.showErrorMessage(CONSTANTS.editorNotSelectorError);
       return;

--- a/ext-src/commands/DiscardSuggestion.ts
+++ b/ext-src/commands/DiscardSuggestion.ts
@@ -39,7 +39,7 @@ export function activateDiscardCommand(context: vscode.ExtensionContext): void {
       return;
     }
 
-    const filename: string | undefined = documentMetaData.fileName;
+    const filename: string | undefined = documentMetaData.absPath;
     const isUserOnProblemFile: boolean = filename === path;
 
     const copyProblems = { ...problems };

--- a/ext-src/extension.ts
+++ b/ext-src/extension.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import * as path from 'path';
 import { AnalyzeDocumentOnSaveConfig } from './config';
 import { RecommendationWebView } from './providers/recommendation.provider';
 import {
@@ -264,15 +263,10 @@ export function activate(context: vscode.ExtensionContext): void {
       }
 
       const documentMetaData = Util.extractMetaDataFromDocument(bufferedEParam);
-      let filePath: string | undefined = undefined;
-
-      if (documentMetaData.relativePath) {
-        filePath = documentMetaData.relativePath;
+      if (!documentMetaData.filePath) {
+        return
       }
-
-      if (!filePath && documentMetaData.filePath) {
-        filePath = path.relative(currentWorkspacePath, documentMetaData.filePath).replace(/\.git$/, '');
-      }
+      const filePath: string = documentMetaData.filePath.replace(/\.git$/, '');
 
       if (!filePath) {
         return;

--- a/ext-src/extension.ts
+++ b/ext-src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { AnalyzeDocumentOnSaveConfig } from './config';
 import { RecommendationWebView } from './providers/recommendation.provider';
 import {
@@ -145,7 +146,7 @@ export function activate(context: vscode.ExtensionContext): void {
         return;
       }
 
-      const documentMetaData = Util.getFileNameFromCurrentEditor();
+      const documentMetaData = Util.getCurrentFile();
 
       if (!documentMetaData) {
         return;
@@ -257,28 +258,27 @@ export function activate(context: vscode.ExtensionContext): void {
       }
 
       const currentWorkSpaceFolder = Util.getRootFolderName();
-      const documentMetaData = Util.extractMetaDataFromDocument(bufferedEParam);
-      let fileName: string | undefined = undefined;
-
-      if (documentMetaData.fileName) {
-        fileName = documentMetaData.fileName;
-      }
-
-      if (!fileName && documentMetaData.filePath) {
-        const splitKey: string | undefined = documentMetaData.filePath
-          .split('/')
-          .pop()
-          ?.replace('.git', '');
-        if (splitKey) {
-          fileName = splitKey;
-        }
-      }
-
-      if (!fileName) {
+      const currentWorkspacePath = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
+      if (currentWorkspacePath === undefined) {
         return;
       }
 
-      const results: Problem[] | undefined = Util.getCurrentEditorProblems(analyzeValue, fileName);
+      const documentMetaData = Util.extractMetaDataFromDocument(bufferedEParam);
+      let filePath: string | undefined = undefined;
+
+      if (documentMetaData.relativePath) {
+        filePath = documentMetaData.relativePath;
+      }
+
+      if (!filePath && documentMetaData.filePath) {
+        filePath = path.relative(currentWorkspacePath, documentMetaData.filePath).replace(/\.git$/, '');
+      }
+
+      if (!filePath) {
+        return;
+      }
+
+      const results: Problem[] | undefined = Util.getCurrentEditorProblems(analyzeValue, filePath);
       if (!results) {
         return;
       }

--- a/ext-src/providers/recommendation.provider.ts
+++ b/ext-src/providers/recommendation.provider.ts
@@ -431,7 +431,7 @@ export class RecommendationWebView implements WebviewViewProvider {
     }
 
     const key = `${initData.path}@@${initData.id}`;
-    if (documentMetadata.fileName !== initData.path) {
+    if (documentMetadata.absPath !== initData.path) {
       throw new Error('handleApplyRecommendation: User editor changed');
     }
 

--- a/ext-src/providers/recommendation.provider.ts
+++ b/ext-src/providers/recommendation.provider.ts
@@ -484,16 +484,15 @@ export class RecommendationWebView implements WebviewViewProvider {
 
   searchFileByName(fileName: string) {
     const searchPattern = `**/${fileName}`;
+
     return workspace.findFiles(searchPattern, '**/node_modules/**', 1);
   }
 
-  async openFileInNewTab(fileName: string) {
-    const searchedFilePath = await this.searchFileByName(fileName);
-    const path: Uri | undefined = searchedFilePath[0];
+  async openFileInNewTab(filePath: string): Promise<void> {
+    if (!filePath) return;
 
-    if (!path) return;
     // Use the `openTextDocument` method to open the document
-    workspace.openTextDocument(Uri.file(path.fsPath)).then(document => {
+    workspace.openTextDocument(Uri.file(filePath)).then(document => {
       // Use the `showTextDocument` method to show the document in a new tab
       window.showTextDocument(document, {
         viewColumn: ViewColumn.One,
@@ -516,8 +515,8 @@ export class RecommendationWebView implements WebviewViewProvider {
       const data = message.data;
       switch (message.type) {
         case 'OPEN_FILE_IN_NEW_TAB':
-          const { name: fileName } = data;
-          this.openFileInNewTab(fileName);
+          const { path: filePath } = data;
+          this.openFileInNewTab(filePath);
           break;
         case 'analysis_current_file':
           this.clear();

--- a/ext-src/providers/recommendation.provider.ts
+++ b/ext-src/providers/recommendation.provider.ts
@@ -425,7 +425,7 @@ export class RecommendationWebView implements WebviewViewProvider {
   }
 
   async handleApplyRecommendation(input: string, initData: CurrentQuestionState) {
-    const documentMetadata = Util.getFileNameFromCurrentEditor();
+    const documentMetadata = Util.getCurrentFile();
     if (!documentMetadata || !initData) {
       throw new Error('handleApplyRecommendation: Editor or Init Data is undefined');
     }

--- a/ext-src/services/submit/submit.service.ts
+++ b/ext-src/services/submit/submit.service.ts
@@ -24,8 +24,7 @@ class SubmitService extends ApiServiceBase {
   async submitTextFile(relativePath: string, fileContent: any, _filePath: string, sessionToken: string) {
     const formData = new FormData()
     formData.append('type', 'text/plain')
-    formData.append('filename', relativePath)
-    formData.append('upload', Buffer.from(fileContent, 'utf-8'), relativePath)
+    formData.append('upload', Buffer.from(fileContent, 'utf-8'), {filepath: relativePath})
     const config = this.getConfig(sessionToken, formData.getHeaders())
     const response = await this.post<SubmitRepresentationResponse>('/submit', formData, config)
     return response

--- a/ext-src/services/submit/submit.service.ts
+++ b/ext-src/services/submit/submit.service.ts
@@ -24,6 +24,7 @@ class SubmitService extends ApiServiceBase {
   async submitTextFile(relativePath: string, fileContent: any, _filePath: string, sessionToken: string) {
     const formData = new FormData()
     formData.append('type', 'text/plain')
+    formData.append('filename', relativePath)
     formData.append('upload', Buffer.from(fileContent, 'utf-8'), {filepath: relativePath})
     const config = this.getConfig(sessionToken, formData.getHeaders())
     const response = await this.post<SubmitRepresentationResponse>('/submit', formData, config)

--- a/ext-src/utils.ts
+++ b/ext-src/utils.ts
@@ -147,7 +147,7 @@ export default class Utils {
 
   static getCurrentFile(): {
     fileName: string;
-    relativePath: string;
+    absPath: string;
     editor: vscode.TextEditor
   } | undefined {
     const editor = vscode.window.activeTextEditor
@@ -162,7 +162,7 @@ export default class Utils {
 
     return {
       fileName,
-      relativePath: documentMetaData.relativePath,
+      absPath: documentMetaData.filePath,
       editor
     }
   }

--- a/ext-src/utils.ts
+++ b/ext-src/utils.ts
@@ -145,8 +145,9 @@ export default class Utils {
     return undefined; // No workspace folder
   }
 
-  static getFileNameFromCurrentEditor(): {
+  static getCurrentFile(): {
     fileName: string;
+    relativePath: string;
     editor: vscode.TextEditor
   } | undefined {
     const editor = vscode.window.activeTextEditor
@@ -161,19 +162,19 @@ export default class Utils {
 
     return {
       fileName,
+      relativePath: documentMetaData.relativePath,
       editor
     }
   }
 
-  static getCurrentEditorProblems(analyzeValue: AnalyzeState, problemFileName: string): Problem[] | undefined {
+  static getCurrentEditorProblems(analyzeValue: AnalyzeState, currentFilePath: string): Problem[] | undefined {
     const results: Problem[] = [];
 
-    for (const [key, value] of Object.entries(analyzeValue)) {
-      const fileNameFromKey: string | undefined = key.split('@@')[0];
-      if (fileNameFromKey === undefined) continue;
+    for (const value of Object.values(analyzeValue)) {
+      if (value.path === undefined) continue;
 
       // verifying that we only show current opened file decorations that are not discarded.
-      if (fileNameFromKey === problemFileName && value.isDiscarded === false) {
+      if (value.path === currentFilePath && value.isDiscarded === false) {
         const problem: Problem = {
           ...value,
           startLine: value.startLine < 0 ? value.startLine * -1 : value.startLine,

--- a/src/components/Analyze/ProblemList/index.spec.tsx
+++ b/src/components/Analyze/ProblemList/index.spec.tsx
@@ -37,7 +37,7 @@ describe('ProblemList component', () => {
   });
 
   test('renders correctly with otherFileWithProblems', () => {
-    const otherFileWithProblems = [{ name: 'file1.txt' }, { name: 'file2.txt' }];
+    const otherFileWithProblems = [{ name: 'file1.txt', path: 'path/to/file1.txt' }, { name: 'file2.txt', path: 'path/to/file2.txt' }];
     const { getByText, getAllByText } = render(
       <RecoilRoot>
         <ProblemList
@@ -55,7 +55,7 @@ describe('ProblemList component', () => {
   });
 
   test('handles opening other files correctly', () => {
-    const otherFileWithProblems = [{ name: 'file1.txt' }];
+    const otherFileWithProblems = [{ name: 'file1.txt', path: 'path/to/file1.txt' }];
     const { getByText } = render(
       <RecoilRoot>
         <ProblemList

--- a/src/components/Analyze/ProblemList/index.spec.tsx
+++ b/src/components/Analyze/ProblemList/index.spec.tsx
@@ -69,7 +69,7 @@ describe('ProblemList component', () => {
     fireEvent.click(getByText('Open'));
     expect(vscode.postMessage).toHaveBeenCalledWith({
       type: 'OPEN_FILE_IN_NEW_TAB',
-      data: { name: 'file1.txt' },
+      data: { path: 'path/to/file1.txt' },
     });
   });
 });

--- a/src/components/Analyze/ProblemList/index.tsx
+++ b/src/components/Analyze/ProblemList/index.tsx
@@ -13,7 +13,7 @@ import { useCallback } from 'react';
 
 export interface ProblemsListProps {
   detectedProblems?: number;
-  otherFileWithProblems?: Array<{ name: string }>;
+  otherFileWithProblems?: Array<{ name: string, path: string }>;
   isEmptyIdentifiedProblemDetected: boolean;
 }
 
@@ -24,12 +24,12 @@ export const ProblemList = ({
 }: ProblemsListProps): JSX.Element => {
   const theme = useTheme();
 
-  const handleOpenOtherFile: (name: string) => React.MouseEventHandler = useCallback(
-    (name: string) => e => {
+  const handleOpenOtherFile: (path: string) => React.MouseEventHandler = useCallback(
+    (path: string) => e => {
       e.preventDefault();
       vscode.postMessage({
         type: 'OPEN_FILE_IN_NEW_TAB',
-        data: { name },
+        data: { path },
       });
     },
     [],
@@ -75,7 +75,7 @@ export const ProblemList = ({
                           size='small'
                           variant='contained'
                           color='primary'
-                          onClick={handleOpenOtherFile(item.name)}
+                          onClick={handleOpenOtherFile(item.path)}
                         >
                           Open
                         </Button>

--- a/src/components/Analyze/index.tsx
+++ b/src/components/Analyze/index.tsx
@@ -26,12 +26,12 @@ export const AnalyzePage = ({
   const currentWorkSpaceProject = useRecoilValue(State.currentWorkSpaceProject);
   const isEmptyIdentifiedProblemDetected = useRecoilValue(State.isEmptyIdentifiedProblemDetected);
 
-  const otherFileWithProblems: Array<{ name: string }> | undefined = useMemo(() => {
+  const otherFileWithProblems: Array<{ name: string, path: string }> | undefined = useMemo(() => {
     if (!identifiedProblems) return undefined;
 
     if (!currentEditor) return undefined;
 
-    const results: Array<{ name: string }> = Object.keys(identifiedProblems)
+    const results: Array<{ path: string }> = Object.keys(identifiedProblems)
       .filter(problemKey => {
         const problem = identifiedProblems[problemKey];
 
@@ -74,15 +74,16 @@ export const AnalyzePage = ({
         const problem = identifiedProblems[problemKey];
 
         return {
-          name: problem.path,
+          path: problem.path,
         };
       });
 
-    const uniqueFiles = Array.from(new Set(results.map(item => item.name)));
+    const uniqueFiles = Array.from(new Set(results.map(item => item.path)));
 
-    return uniqueFiles.map(name => {
+    return uniqueFiles.map(file => {
       return {
-        name,
+        path: file,
+        name: file.split(/\/|\\/g).pop() || '',
       };
     });
   }, [identifiedProblems, currentEditor, currentWorkSpaceProject]);


### PR DESCRIPTION
Previously, the backend was only receiving the name of the file (e.g. c.py for the file a/b/c.py). As a result, all responses received also only contained the name of the file, and it would be impossible to tell apart files with same name in different folders.
The problem seems to lie with the FormData object, which was removing all the path parts of relativePath and leaving only the name. To avoid this, relativePath should instead be provided as the filePath attribute of the FormData.AppendOptions object.

References: https://github.com/form-data/form-data?tab=readme-ov-file#alternative-submission-methods