### PR TITLE
Fix analyze button disabled when analysis fails

### DIFF
--- a/ext-src/commands/AnalyzeDocument.ts
+++ b/ext-src/commands/AnalyzeDocument.ts
@@ -6,7 +6,10 @@ import CONSTANTS from '../constants';
 import Util from '../utils';
 import { getExtensionEventEmitter } from '../events';
 
-export function activateAnalyzeCommand(context: vscode.ExtensionContext, _debug?: vscode.OutputChannel): void {
+export function activateAnalyzeCommand(
+  context: vscode.ExtensionContext,
+  _debug?: vscode.OutputChannel,
+): void {
   const command = CONSTANTS.analyzeDocumentCommand;
 
   const commandHandler = async () => {
@@ -17,7 +20,9 @@ export function activateAnalyzeCommand(context: vscode.ExtensionContext, _debug?
     const sessionToken = new Session(context).get()?.value;
 
     const editor = vscode.window.activeTextEditor;
-    _debug?.appendLine('AnalyzeDocument.ts: activateAnalyzeCommand: editor: ' + JSON.stringify(editor));
+    _debug?.appendLine(
+      'AnalyzeDocument.ts: activateAnalyzeCommand: editor: ' + JSON.stringify(editor),
+    );
 
     // If the user has not opened any file then we can't perform any analysis.
     if (!editor) {
@@ -28,7 +33,11 @@ export function activateAnalyzeCommand(context: vscode.ExtensionContext, _debug?
       throw new Error('activateAnalyzeCommand: Editor is undefined');
     }
 
-    _debug?.appendLine('AnalyzeDocument.ts: activateAnalyzeCommand: editor.document: ' + JSON.stringify(editor.document));
+    _debug?.appendLine(
+      'AnalyzeDocument.ts: activateAnalyzeCommand: editor.document: ' +
+        JSON.stringify(editor.document),
+    );
+
     // If the user has not opened valid document i.e settings page or any other page
     // that is not a code file we will throw an error.
     if (!Util.isValidDocument(editor.document)) {
@@ -41,7 +50,10 @@ export function activateAnalyzeCommand(context: vscode.ExtensionContext, _debug?
       throw new Error('activateAnalyzeCommand: Selected Document is not valid');
     }
 
-    _debug?.appendLine('AnalyzeDocument.ts: activateAnalyzeCommand: Session Token: ' + sessionToken);
+    _debug?.appendLine(
+      'AnalyzeDocument.ts: activateAnalyzeCommand: Session Token: ' + sessionToken,
+    );
+
     // If the user session is not available then we can't request file analysis.
     if (!sessionToken) {
       vscode.window.showErrorMessage(CONSTANTS.sessionTokenUndefined);
@@ -53,10 +65,21 @@ export function activateAnalyzeCommand(context: vscode.ExtensionContext, _debug?
     }
 
     const documentMetaData = Util.extractMetaDataFromDocument(editor.document);
-    _debug?.appendLine('AnalyzeDocument.ts: activateAnalyzeCommand: documentMetaData: ' + JSON.stringify(documentMetaData));
+    _debug?.appendLine(
+      'AnalyzeDocument.ts: activateAnalyzeCommand: documentMetaData: ' +
+        JSON.stringify(documentMetaData),
+    );
 
     Util.withProgress<SubmitRepresentationResponse>(
-      handleDocumentAnalyze(documentMetaData, sessionToken, analyzeState, context, undefined, true, _debug),
+      handleDocumentAnalyze(
+        documentMetaData,
+        sessionToken,
+        analyzeState,
+        context,
+        undefined,
+        true,
+        _debug,
+      ),
       CONSTANTS.analyzeCommandProgressMessage,
     ).then(response => {
       if (response.status === 'pending' || response.status === 'running') {

--- a/ext-src/helpers/HandleDocumentAnalyze.ts
+++ b/ext-src/helpers/HandleDocumentAnalyze.ts
@@ -58,27 +58,27 @@ export const handleDocumentAnalyze = async (
     jobId !== undefined
       ? await submitService.getJobStatus(sessionToken, jobId)
       : await submitService.submitTextFile(
-        metaDataDocument.relativePath,
-        metaDataDocument.fileContent,
-        metaDataDocument.filePath,
-        sessionToken,
-      );
+          metaDataDocument.relativePath,
+          metaDataDocument.fileContent,
+          metaDataDocument.filePath,
+          sessionToken,
+        );
 
   const verifiedResponse = verifyResponseOfSubmit(response);
   if (!verifiedResponse || !verifiedResponse.results) {
     if (!suppressRateLimitErrors) {
-      getExtensionEventEmitter().fire({
-        type: 'Analysis_Error',
-        data: '',
-      });
-      getExtensionEventEmitter().fire({
-        type: 'CURRENT_PROJECT',
-        data: {
-        name: currentWorkSpaceFolder,
-        },
-      });
       vscode.window.showErrorMessage(CONSTANTS.analyzeCommandTimeoutMessage);
     }
+    getExtensionEventEmitter().fire({
+      type: 'Analysis_Error',
+      data: '',
+    });
+    getExtensionEventEmitter().fire({
+      type: 'CURRENT_PROJECT',
+      data: {
+        name: currentWorkSpaceFolder,
+      },
+    });
 
     return failedResponseReturn;
   } else if (verifiedResponse.status === 'failed') {
@@ -121,7 +121,20 @@ export const handleDocumentAnalyze = async (
 
   // convert problem paths to absolute path and normalize them
   const workspaceFolderPath = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
-  if (!workspaceFolderPath) {return failedResponseReturn;}
+  if (!workspaceFolderPath) {
+    getExtensionEventEmitter().fire({
+      type: 'Analysis_Error',
+      data: '',
+    });
+    getExtensionEventEmitter().fire({
+      type: 'CURRENT_PROJECT',
+      data: {
+        name: currentWorkSpaceFolder,
+      },
+    });
+
+    return failedResponseReturn;
+  }
   verifiedResponse.results.forEach(result => {
     result.path = path.join(workspaceFolderPath, result.path);
   });

--- a/ext-src/helpers/HandleDocumentAnalyze.ts
+++ b/ext-src/helpers/HandleDocumentAnalyze.ts
@@ -6,7 +6,7 @@ import { AnalyzeState, Analyze, AnalyseMetaData } from '../state';
 import Util from '../utils';
 import CONSTANTS from '../constants';
 import { getExtensionEventEmitter } from '../events';
-import path from 'path'
+import path from 'path';
 
 const failedResponseReturn: SubmitRepresentationResponse = { jobId: '', status: 'failed' };
 
@@ -47,7 +47,7 @@ export const handleDocumentAnalyze = async (
     getExtensionEventEmitter().fire({
       type: 'CURRENT_PROJECT',
       data: {
-        name: currentWorkSpaceFolder
+        name: currentWorkSpaceFolder,
       },
     });
 
@@ -74,7 +74,7 @@ export const handleDocumentAnalyze = async (
       getExtensionEventEmitter().fire({
         type: 'CURRENT_PROJECT',
         data: {
-          name: currentWorkSpaceFolder
+        name: currentWorkSpaceFolder,
         },
       });
       vscode.window.showErrorMessage(CONSTANTS.analyzeCommandTimeoutMessage);
@@ -89,7 +89,7 @@ export const handleDocumentAnalyze = async (
     getExtensionEventEmitter().fire({
       type: 'CURRENT_PROJECT',
       data: {
-        name: currentWorkSpaceFolder
+        name: currentWorkSpaceFolder,
       },
     });
     vscode.window.showErrorMessage(CONSTANTS.analyzeCommandErrorMessage);
@@ -111,7 +111,7 @@ export const handleDocumentAnalyze = async (
     getExtensionEventEmitter().fire({
       type: 'CURRENT_PROJECT',
       data: {
-        name: currentWorkSpaceFolder
+        name: currentWorkSpaceFolder,
       },
     });
     vscode.window.showErrorMessage(CONSTANTS.analyzeCommandErrorMessage);
@@ -128,7 +128,10 @@ export const handleDocumentAnalyze = async (
 
   let results: AnalyzeState = {};
   const analyzeStateValue = new Analyze(context).get()?.value;
-  _debug?.appendLine('AnalyzeDocument.ts: handleDocumentAnalyze: analyzeStateValue: ' + JSON.stringify(analyzeStateValue));
+  _debug?.appendLine(
+    'AnalyzeDocument.ts: handleDocumentAnalyze: analyzeStateValue: ' +
+      JSON.stringify(analyzeStateValue),
+  );
 
   if (analyzeStateValue) {
     const responseProblemsFilePaths = verifiedResponse.results.map(problem => {
@@ -163,10 +166,7 @@ export const handleDocumentAnalyze = async (
         currFile.editor.document.lineAt(endLine - 1).text.length,
       );
 
-      const text = currFile.editor.document
-        .getText(range)
-        .replace('\n', '')
-        .replace('\t', '');
+      const text = currFile.editor.document.getText(range).replace('\n', '').replace('\t', '');
       if (text.length === 0 || text === '' || text === ' ') {
         return false;
       }
@@ -190,7 +190,9 @@ export const handleDocumentAnalyze = async (
 
   _debug?.appendLine('AnalyzeDocument.ts: Document File path' + currFile.absPath);
   const problems = Util.getCurrentEditorProblems(results, currFile.absPath);
-  _debug?.appendLine('AnalyzeDocument.ts: handleDocumentAnalyze: problems: ' + JSON.stringify(problems));
+  _debug?.appendLine(
+    'AnalyzeDocument.ts: handleDocumentAnalyze: problems: ' + JSON.stringify(problems),
+  );
   if (!problems) {
     getExtensionEventEmitter().fire({
       type: 'Analysis_Error',
@@ -199,7 +201,7 @@ export const handleDocumentAnalyze = async (
     getExtensionEventEmitter().fire({
       type: 'CURRENT_PROJECT',
       data: {
-        name: currentWorkSpaceFolder
+        name: currentWorkSpaceFolder,
       },
     });
     vscode.window.showErrorMessage(CONSTANTS.analyzeCommandErrorMessage);
@@ -210,7 +212,9 @@ export const handleDocumentAnalyze = async (
   const paths = problems.map(item => item.path);
 
   const isUserOnValidEditor = paths.includes(currFile.absPath);
-  _debug?.appendLine('AnalyzeDocument.ts: handleDocumentAnalyze: isUserOnValidEditor: ' + isUserOnValidEditor);
+  _debug?.appendLine(
+    'AnalyzeDocument.ts: handleDocumentAnalyze: isUserOnValidEditor: ' + isUserOnValidEditor,
+  );
   if (isUserOnValidEditor) {
     Util.decorateCurrentEditorWithHighlights(problems, currFile.editor, _debug);
   }
@@ -226,13 +230,12 @@ export const handleDocumentAnalyze = async (
     getExtensionEventEmitter().fire({
       type: 'CURRENT_PROJECT',
       data: {
-        name: currentWorkSpaceFolder
+        name: currentWorkSpaceFolder,
       },
     });
 
-    return verifiedResponse
+    return verifiedResponse;
   }
-
 
   getExtensionEventEmitter().fire({
     type: 'Analysis_Completed',
@@ -242,7 +245,7 @@ export const handleDocumentAnalyze = async (
   getExtensionEventEmitter().fire({
     type: 'CURRENT_PROJECT',
     data: {
-      name: currentWorkSpaceFolder
+      name: currentWorkSpaceFolder,
     },
   });
 


### PR DESCRIPTION
Sometimes when the analyze button is clicked and analysis fails, the button continues having the loading spinner and remains disabled, even though the analysis is no longer running.
https://www.notion.so/metabob/Analyze-button-continues-loading-when-analysis-fails-b82d34e664d04e09942209dd59a778dc?pvs=4